### PR TITLE
rm unused rollup-plugin-resolve module

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "rollup-plugin-filesize": "^1.4.2",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-replace": "^1.1.1",
-    "rollup-plugin-resolve": "0.0.1-predev.1",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-uglify": "^2.0.1",
     "ts-jest": "^20.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,13 +981,9 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@~0.4.13:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -2142,10 +2138,6 @@ rollup-plugin-replace@^1.1.1:
     magic-string "^0.15.2"
     minimatch "^3.0.2"
     rollup-pluginutils "^1.5.0"
-
-rollup-plugin-resolve@0.0.1-predev.1:
-  version "0.0.1-predev.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-resolve/-/rollup-plugin-resolve-0.0.1-predev.1.tgz#cb7f19642a17419101c671e1a8c2cda7af7ac41d"
 
 rollup-plugin-sourcemaps@^0.4.2:
   version "0.4.2"


### PR DESCRIPTION
`rollup-plugin-resolve` is an empty and unused module. Checked the source code there's nothing there.