### PR TITLE
use watchPosition instead of getCurrentPosition

### DIFF
--- a/src/GeoPosition/GeoPosition.tsx
+++ b/src/GeoPosition/GeoPosition.tsx
@@ -34,7 +34,7 @@ export class GeoPosition extends React.Component<
 
   requestGeo = () => {
     this.setState({ isLoading: true });
-    this.geoId = navigator.geolocation.getCurrentPosition(
+    this.geoId = navigator.geolocation.watchPosition(
       (position: Position) =>
         this.setState({
           isLoading: false,


### PR DESCRIPTION
`getCurrentPosition` does not return a `geoId` and thus will always be `undefined`.