### PR TITLE
Enable TypeScript's strict mode to fix bugs and preemptively catch new ones

### DIFF
--- a/src/DeviceMotion/DeviceMotion.tsx
+++ b/src/DeviceMotion/DeviceMotion.tsx
@@ -10,10 +10,10 @@ import { SharedRenderProps } from '../types';
 import { isEmptyChildren } from '../utils';
 
 export interface DeviceMotionProps {
-  acceleration: DeviceAcceleration;
-  accelerationIncludingGravity: DeviceAcceleration;
-  rotationRate: DeviceRotationRate;
-  interval: number;
+  acceleration: DeviceAcceleration | null;
+  accelerationIncludingGravity: DeviceAcceleration | null;
+  rotationRate: DeviceRotationRate | null;
+  interval: number | null;
 }
 
 export class DeviceMotion extends React.Component<
@@ -49,11 +49,11 @@ export class DeviceMotion extends React.Component<
   };
 
   componentDidMount() {
-    window.addEventListener('deviceMotion', this.handleDeviceMotion, true);
+    window.addEventListener('devicemotion', this.handleDeviceMotion, true);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('deviceMotion', this.handleDeviceMotion);
+    window.removeEventListener('devicemotion', this.handleDeviceMotion);
   }
 
   render() {

--- a/src/Mailto.tsx
+++ b/src/Mailto.tsx
@@ -34,8 +34,8 @@ export const Mailto: React.SFC<MailtoProps> = ({
     <a
       href={`mailto:${email}?${qs.stringify({
         subject,
-        cc: cc.join(', '),
-        bcc: bcc.join(', '),
+        cc: cc && cc.join(', '),
+        bcc: bcc && bcc.join(', '),
         body,
       })}`}
       {...props}

--- a/src/Scroll/Scroll.tsx
+++ b/src/Scroll/Scroll.tsx
@@ -23,7 +23,7 @@ export class Scroll extends React.Component<
   ScrollConfig & SharedRenderProps<ScrollProps>,
   ScrollProps
 > {
-  static defaultProps = {
+  static defaultProps: Partial<ScrollConfig> = {
     throttle: 100,
   };
 
@@ -31,7 +31,7 @@ export class Scroll extends React.Component<
 
   handleWindowScroll = throttle(() => {
     this.setState({ x: window.scrollX, y: window.scrollY });
-  }, this.props.throttle);
+  }, this.props.throttle!);
 
   componentDidMount() {
     this.handleWindowScroll();

--- a/src/WindowSize/WindowSize.tsx
+++ b/src/WindowSize/WindowSize.tsx
@@ -23,15 +23,15 @@ export class WindowSize extends React.Component<
   WindowSizeConfig & SharedRenderProps<WindowSizeProps>,
   WindowSizeProps
 > {
-  static defaultProps = {
-    debounce: 100,
+  static defaultProps: Partial<WindowSizeConfig> = {
+    throttle: 100,
   };
 
   state: WindowSizeProps = { width: 0, height: 0 };
 
   handleWindowSize = throttle(() => {
     this.setState({ width: window.innerWidth, height: window.innerHeight });
-  }, this.props.throttle);
+  }, this.props.throttle!);
 
   componentDidMount() {
     this.handleWindowSize();

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -17,7 +17,7 @@
  */
 export const debounce = (func: Function, wait: number, immediate?: boolean) => {
   let timeout: any;
-  return function() {
+  return function(this: any) {
     var context = this,
       args = arguments;
     var later = function() {

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -6,7 +6,7 @@
  * @param wait time
  */
 
-export function throttle(func: Function, wait: Number) {
+export function throttle(this: any, func: Function, wait: Number) {
   let timeout: number | null = null;
   let callbackArgs: IArguments | null = null;
   const context = this;

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -8,7 +8,7 @@
 
 export function throttle(func: Function, wait: Number) {
   let timeout: number | null = null;
-  let callbackArgs = null;
+  let callbackArgs: IArguments | null = null;
   const context = this;
 
   const later = () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "removeComments": true,
     "sourceMap": true,
     "pretty": true,
+    "strict": true,
 
     "stripInternal": true,
     "target": "es5",


### PR DESCRIPTION
Implements the enhancement proposed at #49. Automatically fixes #46 & #48, capturing those errors at compile time. Also fixes #47.

I explained more about the strict mode and why to enable it in #49. It's a setup change with minor consequences for the developer other than enforcing good practices and preemptively catching bugs. I already handled all the errors that appeared after enabling it, so that it builds normally.

I am really sorry if it's too big a change for a newcomer, I could also disable the strict mode and just merge the bug fixes. 🙃 