### PR TITLE
Update to Prettier v1.10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "husky": "^0.14.3",
     "jest": "^20.0.4",
     "lint-staged": "^5.0.0",
-    "prettier": "^1.8.2",
+    "prettier": "^1.10.2",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-test-renderer": "^15.6.1",

--- a/src/Mailto.tsx
+++ b/src/Mailto.tsx
@@ -28,7 +28,7 @@ export const Mailto: React.SFC<MailtoProps> = ({
   bcc,
   body,
   children,
-  ...props,
+  ...props
 }) => {
   return (
     <a

--- a/src/Sms.tsx
+++ b/src/Sms.tsx
@@ -19,7 +19,7 @@ export const Sms: React.SFC<SmsProps> = ({
   phone,
   body,
   children,
-  ...props,
+  ...props
 }) => {
   return (
     <a

--- a/yarn.lock
+++ b/yarn.lock
@@ -2346,9 +2346,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 
 pretty-format@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
Running `yarn format` after updating results in changes to Mailto and
Sms components as a result of prettier/prettier#3313 being shipped in
Prettier v1.9.