### PR TITLE
add webpack's "sideEffects: false" to package.json for better tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.es6.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "test": "jest --env=jsdom",
     "test:watch": "npm run test -- --watch",


### PR DESCRIPTION
Because of webpack/webpack#2867, webpack doesn't always remove all
unused code when a user imports a single component from the library.

Webpack 4 fixes that for libraries that explicitly anounce thmeselves
to be side effect free:
https://github.com/webpack/webpack/tree/next/examples/side-effects.