### PR TITLE
Init state with window.innerWidth & window.innerHeight for WindowSize

### DIFF
--- a/src/WindowSize/WindowSize.tsx
+++ b/src/WindowSize/WindowSize.tsx
@@ -27,14 +27,16 @@ export class WindowSize extends React.Component<
     throttle: 100,
   };
 
-  state: WindowSizeProps = { width: 0, height: 0 };
+  state: WindowSizeProps = {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
 
   handleWindowSize = throttle(() => {
     this.setState({ width: window.innerWidth, height: window.innerHeight });
   }, this.props.throttle!);
 
   componentDidMount() {
-    this.handleWindowSize();
     window.addEventListener('resize', this.handleWindowSize);
   }
 

--- a/src/WindowSize/__tests__/WindowSize.test.tsx
+++ b/src/WindowSize/__tests__/WindowSize.test.tsx
@@ -15,7 +15,7 @@ describe('<WindowSize />', () => {
       ReactDOM.render(
         <WindowSize
           render={sizeProps =>
-            expect(sizeProps).toEqual({ width: 0, height: 0 }) || null
+            expect(sizeProps).toEqual({ width: 1024, height: 768 }) || null
           }
         />,
         node
@@ -34,7 +34,7 @@ describe('<WindowSize />', () => {
         node
       );
 
-      expect(node.innerHTML.includes('0')).toBe(true);
+      expect(node.innerHTML.includes('1024')).toBe(true);
     });
   });
 });

--- a/src/WindowSize/__tests__/withWindowSize.test.tsx
+++ b/src/WindowSize/__tests__/withWindowSize.test.tsx
@@ -14,7 +14,8 @@ describe('withScroll()', () => {
     const hello = 'hi';
 
     const WrappedComponent = withWindowSize<{ hello: string }>(
-      props => expect(props).toEqual({ width: 0, height: 0, hello }) || null
+      props =>
+        expect(props).toEqual({ width: 1024, height: 768, hello }) || null
     );
 
     ReactDOM.render(<WrappedComponent hello={hello} />, node);
@@ -31,7 +32,7 @@ describe('withScroll()', () => {
 
     ReactDOM.render(<WrappedComponent hello={hello} />, node);
 
-    expect(node.innerHTML.includes('0')).toBe(true);
+    expect(node.innerHTML.includes('1024')).toBe(true);
     expect(node.innerHTML.includes('hi')).toBe(true);
   });
 });


### PR DESCRIPTION
`WindowSize` render with `{ width: 0, height: 0 }` when the component mount and re-render immediately because of the `componentDidMount`. 

I think the state should be initialized in `componentWillMount` or the instance field.

```ts
class WindowSize {
  ...
  state: WindowSizeProps = {
    width: window.innerWidth,
    height: window.innerHeight,
  };
}
```

P.S. I have to remove `@types/react` and `@types/react-dom` for running `npm install` without errors(node v8.9.1, npm v5.6.0). I'm not familiar with TypeScript and maybe this PR https://github.com/jaredpalmer/react-fns/pull/71 could fix it