### PR TITLE
Use page<Axis>Offset instead of scroll<Axis>

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -277,12 +277,12 @@ Not implemented
 
 ### Scroll props
 
-* `x`: Horizontal scroll in pixels (`window.scrollX`)
-* `y`: Vertical scroll in pixels (`window.scrollY`)
+* `x`: Horizontal scroll in pixels (`window.pageXOffset`)
+* `y`: Vertical scroll in pixels (`window.pageYOffset`)
 
 ### `<Scroll render/>`
 
-Returns `window.scrollX` and `window.scrollY`.
+Returns `window.pageYOffset` and `window.pageXOffset`.
 
 ```javascript
 import { Scroll } from 'react-fns';
@@ -302,7 +302,7 @@ export default Example;
 
 ### `withScroll()`
 
-Injects `window.scrollX` and `window.scrollY` as `x` and `y` props.
+Injects `window.pageYOffset` and `window.pageXOffset` as `x` and `y` props.
 
 ```javascript
 import { withScroll } from 'react-fns';

--- a/src/Scroll/Scroll.tsx
+++ b/src/Scroll/Scroll.tsx
@@ -31,7 +31,7 @@ export class Scroll extends React.Component<
   state: ScrollProps = { x: 0, y: 0 };
 
   handleWindowScroll = throttle(() => {
-    this.setState({ x: window.scrollX, y: window.scrollY });
+    this.setState({ x: window.pageXOffset, y: window.pageYOffset });
   }, this.props.throttle!);
 
   componentDidMount() {


### PR DESCRIPTION
Thanks for sharing this cool project!
`window.scrollX `and `window.scrollY` are undefined in IE11. [According to MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX#Notes), `pageXOffset` and `pageYOffset` covers all the way to IE 9.