### PR TITLE
WindowSize: Get the window size on first render (in constructor)

### DIFF
--- a/src/WindowSize/WindowSize.tsx
+++ b/src/WindowSize/WindowSize.tsx
@@ -27,7 +27,10 @@ export class WindowSize extends React.Component<
     throttle: 100,
   };
 
-  state: WindowSizeProps = { width: 0, height: 0 };
+  state: WindowSizeProps = {
+    width: window.innerWidth,
+    height: window.innerHeight
+  };
 
   handleWindowSize = throttle(() => {
     this.setState({ width: window.innerWidth, height: window.innerHeight });

--- a/src/WindowSize/__tests__/WindowSize.test.tsx
+++ b/src/WindowSize/__tests__/WindowSize.test.tsx
@@ -15,7 +15,7 @@ describe('<WindowSize />', () => {
       ReactDOM.render(
         <WindowSize
           render={sizeProps =>
-            expect(sizeProps).toEqual({ width: 0, height: 0 }) || null
+            expect(sizeProps).toEqual({ width: 1024, height: 768 }) || null
           }
         />,
         node

--- a/src/WindowSize/__tests__/withWindowSize.test.tsx
+++ b/src/WindowSize/__tests__/withWindowSize.test.tsx
@@ -14,7 +14,7 @@ describe('withScroll()', () => {
     const hello = 'hi';
 
     const WrappedComponent = withWindowSize<{ hello: string }>(
-      props => expect(props).toEqual({ width: 0, height: 0, hello }) || null
+      props => expect(props).toEqual({ width: 1024, height: 768, hello }) || null
     );
 
     ReactDOM.render(<WrappedComponent hello={hello} />, node);
@@ -31,7 +31,8 @@ describe('withScroll()', () => {
 
     ReactDOM.render(<WrappedComponent hello={hello} />, node);
 
-    expect(node.innerHTML.includes('0')).toBe(true);
+    expect(node.innerHTML.includes('1024')).toBe(true);
+    expect(node.innerHTML.includes('768')).toBe(true);
     expect(node.innerHTML.includes('hi')).toBe(true);
   });
 });


### PR DESCRIPTION
Hello, thanks for a great library. I am using `react-fns`’ `WindowSize` to render a responsive toolbar, like this:

```js
function Toolbar ({ items }) {
  return (
    <WindowSize
      render={({ width, height }) => (
        width < 720
          ? <MobileToolbar items={items} />
          : <DesktopToolbar items={items} />
      )}
    />
  )
}
```

> **Aside performance note:** Both `MobileToolbar` and `DesktopToolbar` are `PureComponent`, so even though `Toolbar` re-renders every time window is resized, `MobileToolbar` and `DesktopToolbar` will only render when `items` changed.

However, based on my testing on desktop, when the app runs, the `MobileToolbar` gets rendered for a brief moment, before `DesktopToolbar` replaces it. Upon further investigation, I found that `WindowSize` sets the initial state to `(0, 0)`.

This PR makes `WindowSize` obtain the actual window size in the constructor.