### PR TITLE
Fix <Mailto /> and <Sms /> anchor links in documentation.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,9 +37,9 @@ title: API Reference
   * [`<Locales render/>`](#locales-render)
   * [`withLocales()`](#withlocales)
 * [Utility Components](#utility-components)
-  * [`<Mailto />`](#mailto-)
+  * [`<Mailto />`](#mailto)
     * [Mailto props](#mailto-props)
-  * [`<Sms />`](#sms-)
+  * [`<Sms />`](#sms)
     * [Sms props](#sms-props)
 
 ## DeviceMotion


### PR DESCRIPTION
Anchor links for Mailto and Sms are broken on the API documentation [page](https://react-fns.netlify.com/docs/en/api.html). This should fix it.

Thanks for a great project 😃 