### PR TITLE
Guard against state updates on unmounted component

### DIFF
--- a/src/WindowSize/WindowSize.tsx
+++ b/src/WindowSize/WindowSize.tsx
@@ -33,6 +33,7 @@ export class WindowSize extends React.Component<
   };
 
   handleWindowSize = throttle(() => {
+    if (this.unmounted) return;
     this.setState({ width: window.innerWidth, height: window.innerHeight });
   }, this.props.throttle!);
 
@@ -42,6 +43,7 @@ export class WindowSize extends React.Component<
   }
 
   componentWillUnmount() {
+    this.unmounted = true;
     window.removeEventListener('resize', this.handleWindowSize);
   }
 

--- a/src/WindowSize/WindowSize.tsx
+++ b/src/WindowSize/WindowSize.tsx
@@ -26,6 +26,8 @@ export class WindowSize extends React.Component<
   static defaultProps: Partial<WindowSizeConfig> = {
     throttle: 100,
   };
+  
+  unmounted: boolean;
 
   state: WindowSizeProps = {
     width: window.innerWidth,


### PR DESCRIPTION
Getting: `Warning: Can't perform a React state update on an unmounted component` on a component using withWindowSize that is being re-rendered within 100ms (default throttle).

This should fix that.